### PR TITLE
Square avatars

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "printWidth": 100,
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true
+ }

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ import Avatar from "boring-avatars";
 | Prop    | Type                                                         |
 | ------- | ------------------------------------------------------------ |
 | size    | number or string                                             |
+| square  | boolean                                                      |
 | name    | string                                                       |
 | variant | oneOf: `marble`, `beam`, `pixel`,`sunset`, `ring`, `bauhaus` |
 | colors  | array of colors                                              |
@@ -49,7 +50,7 @@ import Avatar from "boring-avatars";
 
 ## Source
 
-You can embed your boring avatars using the boring avatars source. 
+You can embed your boring avatars using the boring avatars source.
 
 To choose a random avatar from a specific user and a color palette, the format follows:
 
@@ -60,5 +61,3 @@ https://source.boringavatars.com/marble/120/Maria%20Mitchell?colors=264653,2a9d8
 
 
 For more information, [check out the README](https://github.com/hihayk/boring-avatars-service/blob/main/README.md)
-
-

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,7 @@ declare module "boring-avatars" {
   export interface AvatarProps {
     size?: number | string;
     name?: string;
+    square?: boolean;
     variant?: "marble" | "beam" | "pixel" | "sunset" | "ring" | "bauhaus";
     colors?: string[];
   }

--- a/src/demo/playground.js
+++ b/src/demo/playground.js
@@ -1,12 +1,12 @@
-import React, { useEffect, useRef, useState } from 'react'
-import styled from 'styled-components'
-import { SegmentGroup, Segment, Button, BaseStyles, ColorDot } from './ui-system'
-import colors from 'nice-color-palettes'
-import { exampleNames } from './example-names'
-import Avatar from '../lib'
-import { CopyToClipboard } from 'react-copy-to-clipboard'
+import React, { useEffect, useRef, useState } from 'react';
+import styled from 'styled-components';
+import { SegmentGroup, Segment, Button, BaseStyles, ColorDot } from './ui-system';
+import colors from 'nice-color-palettes';
+import { exampleNames } from './example-names';
+import Avatar from '../lib';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
 
-const paletteColors = colors
+const paletteColors = colors;
 
 const Header = styled.header`
   display: grid;
@@ -14,34 +14,34 @@ const Header = styled.header`
   padding: var(--pagePadding);
   align-items: center;
   grid-gap: var(--sp-s);
-`
+`;
 
 const ColorsSection = styled.div`
   display: inline-grid;
   grid-template-columns: repeat(5, 1fr);
   max-width: max-content;
   grid-gap: var(--sp-xs);
-`
+`;
 
 const AvatarsGrid = styled.div`
   display: grid;
   grid-gap: var(--sp-l) var(--sp-s);
   grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));
   padding: var(--pagePadding);
-`
+`;
 
 const AvatarContainer = styled.div`
   display: grid;
   grid-gap: var(--sp-s);
   padding: 0 var(--sp-m);
   font-size: 0.8rem;
-`
+`;
 
 const AvatarSection = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-`
+`;
 
 const Input = styled.input`
   padding: var(--textbox);
@@ -63,24 +63,24 @@ const Input = styled.input`
     border-color: var(--c-fieldFocus);
     outline: none;
   }
-`
+`;
 
 const AvatarWrapper = ({ name, playgroundColors, size, variant }) => {
-  const [avatarName, setAvatarName] = useState(name)
-  const handleFocus = (event) => event.target.select()
+  const [avatarName, setAvatarName] = useState(name);
+  const handleFocus = (event) => event.target.select();
   const ref = useRef();
-  const [copyValue, setCopyValue] = useState(name)
+  const [copyValue, setCopyValue] = useState(name);
 
   useEffect(() => {
-    if(ref.current) {
-      const svgNode = ref.current.innerHTML
-      const svgStart = svgNode.indexOf('<svg')
-      const svgEnd = svgNode.indexOf('</svg>') + 6
-      const svgResult = svgNode.substring(svgStart, svgEnd).toString()
+    if (ref.current) {
+      const svgNode = ref.current.innerHTML;
+      const svgStart = svgNode.indexOf('<svg');
+      const svgEnd = svgNode.indexOf('</svg>') + 6;
+      const svgResult = svgNode.substring(svgStart, svgEnd).toString();
 
-      setCopyValue(svgResult)
+      setCopyValue(svgResult);
     }
-  }, [copyValue, variant, playgroundColors])
+  }, [copyValue, variant, playgroundColors]);
 
   return (
     <AvatarContainer>
@@ -94,57 +94,55 @@ const AvatarWrapper = ({ name, playgroundColors, size, variant }) => {
       </AvatarSection>
       <Input
         value={avatarName}
-        onChange={e => setAvatarName(e.target.value)}
+        onChange={(e) => setAvatarName(e.target.value)}
         onFocus={(e) => handleFocus(e)}
       />
       <CopyToClipboard text={copyValue}>
         <Button>Copy</Button>
       </CopyToClipboard>
     </AvatarContainer>
-  )
-}
+  );
+};
 
-const getRandomPaletteIndex = () => Math.floor(Math.random() * paletteColors.length)
+const getRandomPaletteIndex = () => Math.floor(Math.random() * paletteColors.length);
 
 const avatarSizes = {
   small: 40,
   medium: 80,
   large: 128,
-}
+};
 
 const SizeDotWrapper = styled(Button)`
-  ${p => p.isSelected && `background-color: var(--c-background)`};
-  ${p => !p.isSelected && `color: var(--c-fade)`};
+  ${(p) => p.isSelected && `background-color: var(--c-background)`};
+  ${(p) => !p.isSelected && `color: var(--c-fade)`};
 
   &:hover {
-    ${p => p.isSelected && `background-color: var(--c-background)`};
+    ${(p) => p.isSelected && `background-color: var(--c-background)`};
   }
-`
+`;
 
 const Dot = styled.div`
-  width: ${p => p.size}px;
-  height: ${p => p.size}px;
+  width: ${(p) => p.size}px;
+  height: ${(p) => p.size}px;
   background-color: currentColor;
   border-radius: 10rem;
-`
+`;
 
-const SizeDot = ({size, isSelected, ...props}) => {
+const SizeDot = ({ size, isSelected, ...props }) => {
   const getSize = () => {
-    switch(size) {
+    switch (size) {
       case avatarSizes.small:
-        return 8
+        return 8;
       case avatarSizes.medium:
-        return 14
+        return 14;
       case avatarSizes.large:
-        return 20
+        return 20;
       default:
-        return 0
+        return 0;
     }
-  }
-  return(
-    <SizeDotWrapper isSelected={isSelected} icon={<Dot size={getSize()}/>} {...props} />
-  )
-}
+  };
+  return <SizeDotWrapper isSelected={isSelected} icon={<Dot size={getSize()} />} {...props} />;
+};
 
 const variants = {
   bauhaus: 'bauhaus',
@@ -152,50 +150,72 @@ const variants = {
   sunset: 'sunset',
   pixel: 'pixel',
   marble: 'marble',
-  beam: 'beam'
-}
+  beam: 'beam',
+};
 
 const Playground = () => {
-  const defaultPlaygroundColors = paletteColors[66]
-  const [playgroundColors, setPlaygroundColors] = useState(defaultPlaygroundColors)
+  const defaultPlaygroundColors = paletteColors[66];
+  const [playgroundColors, setPlaygroundColors] = useState(defaultPlaygroundColors);
 
-  const [darkMode, setDarkMode] = useState(false)
-  const [dotColor0, setDotColor0] = useState(playgroundColors[0])
-  const [dotColor1, setDotColor1] = useState(playgroundColors[1])
-  const [dotColor2, setDotColor2] = useState(playgroundColors[2])
-  const [dotColor3, setDotColor3] = useState(playgroundColors[3])
-  const [dotColor4, setDotColor4] = useState(playgroundColors[4])
+  const [darkMode, setDarkMode] = useState(false);
+  const [dotColor0, setDotColor0] = useState(playgroundColors[0]);
+  const [dotColor1, setDotColor1] = useState(playgroundColors[1]);
+  const [dotColor2, setDotColor2] = useState(playgroundColors[2]);
+  const [dotColor3, setDotColor3] = useState(playgroundColors[3]);
+  const [dotColor4, setDotColor4] = useState(playgroundColors[4]);
 
-  const filteredColors = [dotColor0, dotColor1, dotColor2, dotColor3, dotColor4]
+  const filteredColors = [dotColor0, dotColor1, dotColor2, dotColor3, dotColor4];
 
   const handleRandomColors = () => {
-    setPlaygroundColors(
-      paletteColors[getRandomPaletteIndex()]
-    )
-  }
+    setPlaygroundColors(paletteColors[getRandomPaletteIndex()]);
+  };
 
   useEffect(() => {
-    setDotColor0(playgroundColors[0])
-    setDotColor1(playgroundColors[1])
-    setDotColor2(playgroundColors[2])
-    setDotColor3(playgroundColors[3])
-    setDotColor4(playgroundColors[4])
-  }, [playgroundColors])
+    setDotColor0(playgroundColors[0]);
+    setDotColor1(playgroundColors[1]);
+    setDotColor2(playgroundColors[2]);
+    setDotColor3(playgroundColors[3]);
+    setDotColor4(playgroundColors[4]);
+  }, [playgroundColors]);
 
-  const [avatarSize, setAvatarSize] = useState(avatarSizes.medium)
-  const [variant, setVariant] = useState(variants.pixel)
+  const [avatarSize, setAvatarSize] = useState(avatarSizes.medium);
+  const [variant, setVariant] = useState(variants.pixel);
 
   return (
     <>
       <BaseStyles darkMode={darkMode} />
       <Header>
         <SegmentGroup>
-          <Segment onClick={() => setVariant(variants.pixel)} isSelected={variant === variants.pixel}>Pixel</Segment>
-          <Segment onClick={() => setVariant(variants.sunset)} isSelected={variant === variants.sunset}>Sunset</Segment>
-          <Segment onClick={() => setVariant(variants.ring)} isSelected={variant === variants.ring}>Ring</Segment>
-          <Segment onClick={() => setVariant(variants.marble)} isSelected={variant === variants.marble}>Marble</Segment>
-          <Segment onClick={() => setVariant(variants.beam)} isSelected={variant === variants.beam}>Beam</Segment>
-          <Segment onClick={() => setVariant(variants.bauhaus)} isSelected={variant === variants.bauhaus}>Bauhaus</Segment>
+          <Segment
+            onClick={() => setVariant(variants.pixel)}
+            isSelected={variant === variants.pixel}
+          >
+            Pixel
+          </Segment>
+          <Segment
+            onClick={() => setVariant(variants.sunset)}
+            isSelected={variant === variants.sunset}
+          >
+            Sunset
+          </Segment>
+          <Segment onClick={() => setVariant(variants.ring)} isSelected={variant === variants.ring}>
+            Ring
+          </Segment>
+          <Segment
+            onClick={() => setVariant(variants.marble)}
+            isSelected={variant === variants.marble}
+          >
+            Marble
+          </Segment>
+          <Segment onClick={() => setVariant(variants.beam)} isSelected={variant === variants.beam}>
+            Beam
+          </Segment>
+          <Segment
+            onClick={() => setVariant(variants.bauhaus)}
+            isSelected={variant === variants.bauhaus}
+          >
+            Bauhaus
+          </Segment>
         </SegmentGroup>
         <ColorsSection>
           <ColorDot value={dotColor0} onChange={(color) => setDotColor0(color)} />
@@ -239,7 +259,7 @@ const Playground = () => {
         ))}
       </AvatarsGrid>
     </>
-  )
-}
+  );
+};
 
-export default Playground
+export default Playground;

--- a/src/demo/playground.js
+++ b/src/demo/playground.js
@@ -65,7 +65,7 @@ const Input = styled.input`
   }
 `;
 
-const AvatarWrapper = ({ name, playgroundColors, size, variant }) => {
+const AvatarWrapper = ({ name, playgroundColors, size, square, variant }) => {
   const [avatarName, setAvatarName] = useState(name);
   const handleFocus = (event) => event.target.select();
   const ref = useRef();
@@ -90,6 +90,7 @@ const AvatarWrapper = ({ name, playgroundColors, size, variant }) => {
           colors={playgroundColors}
           size={size}
           variant={variants[variant]}
+          square={square}
         />
       </AvatarSection>
       <Input
@@ -180,6 +181,7 @@ const Playground = () => {
 
   const [avatarSize, setAvatarSize] = useState(avatarSizes.medium);
   const [variant, setVariant] = useState(variants.pixel);
+  const [isSquare, setSquare] = useState(false);
 
   return (
     <>
@@ -226,6 +228,7 @@ const Playground = () => {
         </ColorsSection>
 
         <Button onClick={() => handleRandomColors()}>Random palette</Button>
+        <Button onClick={() => setSquare(!isSquare)}>{isSquare ? 'Round' : 'Square'}</Button>
         <SegmentGroup>
           {Object.entries(avatarSizes).map(([key, value], index) => (
             <SizeDot
@@ -252,6 +255,7 @@ const Playground = () => {
           <AvatarWrapper
             key={name}
             size={avatarSize}
+            square={isSquare}
             name={exampleName}
             playgroundColors={filteredColors}
             variant={variant}

--- a/src/lib/components/avatar-bauhaus.js
+++ b/src/lib/components/avatar-bauhaus.js
@@ -31,7 +31,7 @@ const AvatarBauhaus = (props) => {
       height={props.size}
     >
       <mask id="mask__bauhaus" maskUnits="userSpaceOnUse" x={0} y={0} width={SIZE} height={SIZE}>
-        <rect width={SIZE} height={SIZE} rx={SIZE * 2} fill="white" />
+        <rect width={SIZE} height={SIZE} rx={!props.square && SIZE * 2} fill="white" />
       </mask>
       <g mask="url(#mask__bauhaus)">
         <rect width={SIZE} height={SIZE} fill={properties[0].color} />

--- a/src/lib/components/avatar-bauhaus.js
+++ b/src/lib/components/avatar-bauhaus.js
@@ -1,67 +1,67 @@
-import * as React from "react"
-import { getNumber, getUnit, getRandomColor, getBoolean } from '../utilities'
+import * as React from 'react';
+import { getNumber, getUnit, getRandomColor, getBoolean } from '../utilities';
 
-const ELEMENTS = 4
-const SIZE = 80
+const ELEMENTS = 4;
+const SIZE = 80;
 
 function generateColors(name, colors) {
-  const numFromName = getNumber(name)
-  const range = colors && colors.length
+  const numFromName = getNumber(name);
+  const range = colors && colors.length;
 
-  const elementsProperties = Array.from({length: ELEMENTS}, (_,i) => ({
+  const elementsProperties = Array.from({ length: ELEMENTS }, (_, i) => ({
     color: getRandomColor(numFromName + i, colors, range),
-    translateX: getUnit(numFromName * (i + 1), (SIZE/2 - (i + 17)), 1),
-    translateY: getUnit(numFromName * (i + 1), (SIZE/2 - (i + 17)), 2),
+    translateX: getUnit(numFromName * (i + 1), SIZE / 2 - (i + 17), 1),
+    translateY: getUnit(numFromName * (i + 1), SIZE / 2 - (i + 17), 2),
     rotate: getUnit(numFromName * (i + 1), 360),
-    isSquare: getBoolean(numFromName, 2)
+    isSquare: getBoolean(numFromName, 2),
   }));
 
-
-  return elementsProperties
+  return elementsProperties;
 }
 
-const AvatarBauhaus = ( props ) => {
-  const properties = generateColors(props.name, props.colors)
+const AvatarBauhaus = (props) => {
+  const properties = generateColors(props.name, props.colors);
 
   return (
     <svg
-      viewBox={"0 0 " + SIZE + " " + SIZE}
+      viewBox={'0 0 ' + SIZE + ' ' + SIZE}
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       width={props.size}
       height={props.size}
     >
-      <mask
-        id="mask__bauhaus"
-        maskUnits="userSpaceOnUse"
-        x={0}
-        y={0}
-        width={SIZE}
-        height={SIZE}
-      >
-        <rect width={SIZE} height={SIZE} rx={SIZE*2} fill="white" />
+      <mask id="mask__bauhaus" maskUnits="userSpaceOnUse" x={0} y={0} width={SIZE} height={SIZE}>
+        <rect width={SIZE} height={SIZE} rx={SIZE * 2} fill="white" />
       </mask>
       <g mask="url(#mask__bauhaus)">
-        <rect
-          width={SIZE}
-          height={SIZE}
-          fill={properties[0].color}
-        />
+        <rect width={SIZE} height={SIZE} fill={properties[0].color} />
         <rect
           x={(SIZE - 60) / 2}
           y={(SIZE - 20) / 2}
           width={SIZE}
-          height={properties[1].isSquare ? SIZE : SIZE/8}
+          height={properties[1].isSquare ? SIZE : SIZE / 8}
           fill={properties[1].color}
-          transform={"translate(" + (properties[1].translateX) + " " + (properties[1].translateY) + ") rotate(" + properties[1].rotate + " " + SIZE / 2 + " " + SIZE / 2  +")"}
+          transform={
+            'translate(' +
+            properties[1].translateX +
+            ' ' +
+            properties[1].translateY +
+            ') rotate(' +
+            properties[1].rotate +
+            ' ' +
+            SIZE / 2 +
+            ' ' +
+            SIZE / 2 +
+            ')'
+          }
         />
         <circle
           cx={SIZE / 2}
           cy={SIZE / 2}
           fill={properties[2].color}
-          r={SIZE/5}
-          transform={"translate(" + properties[2].translateX + " " + properties[2].translateY + ")"}
-          />
+          r={SIZE / 5}
+          transform={'translate(' + properties[2].translateX + ' ' + properties[2].translateY + ')'}
+        />
         <line
           x1={0}
           y1={SIZE / 2}
@@ -69,11 +69,23 @@ const AvatarBauhaus = ( props ) => {
           y2={SIZE / 2}
           strokeWidth={2}
           stroke={properties[3].color}
-          transform={"translate(" + properties[3].translateX + " " + properties[3].translateY + ") rotate(" + properties[3].rotate + " " + SIZE / 2 + " " + SIZE / 2 +")"}
+          transform={
+            'translate(' +
+            properties[3].translateX +
+            ' ' +
+            properties[3].translateY +
+            ') rotate(' +
+            properties[3].rotate +
+            ' ' +
+            SIZE / 2 +
+            ' ' +
+            SIZE / 2 +
+            ')'
+          }
         />
       </g>
     </svg>
-  )
-}
+  );
+};
 
-export default AvatarBauhaus
+export default AvatarBauhaus;

--- a/src/lib/components/avatar-bauhaus.js
+++ b/src/lib/components/avatar-bauhaus.js
@@ -30,7 +30,6 @@ const AvatarBauhaus = ( props ) => {
       xmlns="http://www.w3.org/2000/svg"
       width={props.size}
       height={props.size}
-      {...props}
     >
       <mask
         id="mask__bauhaus"

--- a/src/lib/components/avatar-bauhaus.js
+++ b/src/lib/components/avatar-bauhaus.js
@@ -39,13 +39,12 @@ const AvatarBauhaus = ( props ) => {
         width={SIZE}
         height={SIZE}
       >
-        <rect width={SIZE} height={SIZE} rx={SIZE / 2} fill="#fff" />
+        <rect width={SIZE} height={SIZE} rx={SIZE*2} fill="white" />
       </mask>
       <g mask="url(#mask__bauhaus)">
         <rect
           width={SIZE}
           height={SIZE}
-          rx={SIZE / 2}
           fill={properties[0].color}
         />
         <rect

--- a/src/lib/components/avatar-beam.js
+++ b/src/lib/components/avatar-beam.js
@@ -1,17 +1,16 @@
-import * as React from "react"
-import { getNumber, getUnit, getBoolean, getRandomColor, getContrast } from '../utilities'
+import * as React from 'react';
+import { getNumber, getUnit, getBoolean, getRandomColor, getContrast } from '../utilities';
 
-const SIZE = 36
+const SIZE = 36;
 
 function generateData(name, colors) {
-  const numFromName = getNumber(name)
-  const range = colors && colors.length
-  const wrapperColor = getRandomColor(numFromName, colors, range)
-  const preTranslateX = getUnit(numFromName, 10, 1)
-  const wrapperTranslateX = preTranslateX < 5 ? (preTranslateX + SIZE/9) : preTranslateX
-  const preTranslateY = getUnit(numFromName, 10, 2)
-  const wrapperTranslateY = preTranslateY < 5 ? (preTranslateY + SIZE/9) : preTranslateY
-
+  const numFromName = getNumber(name);
+  const range = colors && colors.length;
+  const wrapperColor = getRandomColor(numFromName, colors, range);
+  const preTranslateX = getUnit(numFromName, 10, 1);
+  const wrapperTranslateX = preTranslateX < 5 ? preTranslateX + SIZE / 9 : preTranslateX;
+  const preTranslateY = getUnit(numFromName, 10, 2);
+  const wrapperTranslateY = preTranslateY < 5 ? preTranslateY + SIZE / 9 : preTranslateY;
 
   const data = {
     wrapperColor: wrapperColor,
@@ -20,67 +19,110 @@ function generateData(name, colors) {
     wrapperTranslateX: wrapperTranslateX,
     wrapperTranslateY: wrapperTranslateY,
     wrapperRotate: getUnit(numFromName, 360),
-    wrapperScale: (1 + (getUnit(numFromName, SIZE / 12) / 10)),
+    wrapperScale: 1 + getUnit(numFromName, SIZE / 12) / 10,
     isMouthOpen: getBoolean(numFromName, 2),
     isCircle: getBoolean(numFromName, 1),
-    eyeSpread: getUnit(numFromName, 5) ,
+    eyeSpread: getUnit(numFromName, 5),
     mouthSpread: getUnit(numFromName, 3),
     faceRotate: getUnit(numFromName, 10, 3),
-    faceTranslateX: wrapperTranslateX > (SIZE/6) ? wrapperTranslateX/2 : getUnit(numFromName, 8, 1),
-    faceTranslateY: wrapperTranslateY > (SIZE/6) ? wrapperTranslateY/2 : getUnit(numFromName, 7, 2),
+    faceTranslateX:
+      wrapperTranslateX > SIZE / 6 ? wrapperTranslateX / 2 : getUnit(numFromName, 8, 1),
+    faceTranslateY:
+      wrapperTranslateY > SIZE / 6 ? wrapperTranslateY / 2 : getUnit(numFromName, 7, 2),
   };
 
-  return data
+  return data;
 }
 
-const AvatarBeam = ( props ) => {
-  const data = generateData(props.name, props.colors)
+const AvatarBeam = (props) => {
+  const data = generateData(props.name, props.colors);
 
   return (
     <svg
-      viewBox={"0 0 " + SIZE + " " + SIZE}
+      viewBox={'0 0 ' + SIZE + ' ' + SIZE}
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       width={props.size}
       height={props.size}
     >
-      <mask
-        id="mask__beam"
-        maskUnits="userSpaceOnUse"
-        x={0}
-        y={0}
-        width={SIZE}
-        height={SIZE}
-      >
-        <rect width={SIZE} height={SIZE} rx={SIZE*2} fill="white"/>
+      <mask id="mask__beam" maskUnits="userSpaceOnUse" x={0} y={0} width={SIZE} height={SIZE}>
+        <rect width={SIZE} height={SIZE} rx={SIZE * 2} fill="white" />
       </mask>
       <g mask="url(#mask__beam)">
-        <rect
-          width={SIZE}
-          height={SIZE}
-          fill={data.backgroundColor}
-        />
+        <rect width={SIZE} height={SIZE} fill={data.backgroundColor} />
         <rect
           x="0"
           y="0"
           width={SIZE}
           height={SIZE}
-          transform={"translate(" + data.wrapperTranslateX + " " + data.wrapperTranslateY + ") rotate(" + data.wrapperRotate + " " + SIZE / 2 + " " + SIZE / 2  +") scale(" + data.wrapperScale + ")"}
+          transform={
+            'translate(' +
+            data.wrapperTranslateX +
+            ' ' +
+            data.wrapperTranslateY +
+            ') rotate(' +
+            data.wrapperRotate +
+            ' ' +
+            SIZE / 2 +
+            ' ' +
+            SIZE / 2 +
+            ') scale(' +
+            data.wrapperScale +
+            ')'
+          }
           fill={data.wrapperColor}
-          rx={data.isCircle ? SIZE : SIZE/6}
+          rx={data.isCircle ? SIZE : SIZE / 6}
         />
-        <g transform={"translate(" + data.faceTranslateX + " " + data.faceTranslateY + ") rotate("+ data.faceRotate + " " + SIZE / 2 + " " + SIZE / 2  +")"}>
+        <g
+          transform={
+            'translate(' +
+            data.faceTranslateX +
+            ' ' +
+            data.faceTranslateY +
+            ') rotate(' +
+            data.faceRotate +
+            ' ' +
+            SIZE / 2 +
+            ' ' +
+            SIZE / 2 +
+            ')'
+          }
+        >
           {data.isMouthOpen ? (
-              <path d={"M15 "+ (19 + data.mouthSpread) + "c2 1 4 1 6 0"} stroke={data.faceColor} fill="none" strokeLinecap="round" />
-            ) : (
-              <path d={"M13,"+ (19 + data.mouthSpread) + " a1,0.75 0 0,0 10,0"} fill={data.faceColor} />
+            <path
+              d={'M15 ' + (19 + data.mouthSpread) + 'c2 1 4 1 6 0'}
+              stroke={data.faceColor}
+              fill="none"
+              strokeLinecap="round"
+            />
+          ) : (
+            <path
+              d={'M13,' + (19 + data.mouthSpread) + ' a1,0.75 0 0,0 10,0'}
+              fill={data.faceColor}
+            />
           )}
-          <rect x={14 - data.eyeSpread} y={14} width={1.5} height={2} rx={1} stroke="none" fill={data.faceColor} />
-          <rect x={20 + data.eyeSpread} y={14} width={1.5} height={2} rx={1} stroke="none" fill={data.faceColor} />
+          <rect
+            x={14 - data.eyeSpread}
+            y={14}
+            width={1.5}
+            height={2}
+            rx={1}
+            stroke="none"
+            fill={data.faceColor}
+          />
+          <rect
+            x={20 + data.eyeSpread}
+            y={14}
+            width={1.5}
+            height={2}
+            rx={1}
+            stroke="none"
+            fill={data.faceColor}
+          />
         </g>
       </g>
     </svg>
-  )
-}
+  );
+};
 
-export default AvatarBeam
+export default AvatarBeam;

--- a/src/lib/components/avatar-beam.js
+++ b/src/lib/components/avatar-beam.js
@@ -46,7 +46,7 @@ const AvatarBeam = (props) => {
       height={props.size}
     >
       <mask id="mask__beam" maskUnits="userSpaceOnUse" x={0} y={0} width={SIZE} height={SIZE}>
-        <rect width={SIZE} height={SIZE} rx={SIZE * 2} fill="white" />
+        <rect width={SIZE} height={SIZE} rx={!props.square && SIZE * 2} fill="white" />
       </mask>
       <g mask="url(#mask__beam)">
         <rect width={SIZE} height={SIZE} fill={data.backgroundColor} />

--- a/src/lib/components/avatar-beam.js
+++ b/src/lib/components/avatar-beam.js
@@ -52,18 +52,12 @@ const AvatarBeam = ( props ) => {
         width={SIZE}
         height={SIZE}
       >
-        <rect
-          width={SIZE}
-          height={SIZE}
-          rx={20}
-          fill="white"
-        />
+        <rect width={SIZE} height={SIZE} rx={SIZE*2} fill="white"/>
       </mask>
-      <g mask="url(#mask__beam)" fill="transparent">
+      <g mask="url(#mask__beam)">
         <rect
           width={SIZE}
           height={SIZE}
-          rx={20}
           fill={data.backgroundColor}
         />
         <rect

--- a/src/lib/components/avatar-beam.js
+++ b/src/lib/components/avatar-beam.js
@@ -43,7 +43,6 @@ const AvatarBeam = ( props ) => {
       xmlns="http://www.w3.org/2000/svg"
       width={props.size}
       height={props.size}
-      {...props}
     >
       <mask
         id="mask__beam"

--- a/src/lib/components/avatar-marble.js
+++ b/src/lib/components/avatar-marble.js
@@ -31,7 +31,7 @@ const AvatarMarble = (props) => {
       height={props.size}
     >
       <mask id="mask__marble" maskUnits="userSpaceOnUse" x={0} y={0} width={SIZE} height={SIZE}>
-        <rect width={SIZE} height={SIZE} rx={SIZE * 2} fill="white" />
+        <rect width={SIZE} height={SIZE} rx={!props.square && SIZE * 2} fill="white" />
       </mask>
       <g mask="url(#mask__marble)">
         <rect width={SIZE} height={SIZE} rx="2" fill={properties[0].color} />

--- a/src/lib/components/avatar-marble.js
+++ b/src/lib/components/avatar-marble.js
@@ -1,61 +1,82 @@
-import * as React from "react"
-import { getNumber, getUnit, getRandomColor } from '../utilities'
+import * as React from 'react';
+import { getNumber, getUnit, getRandomColor } from '../utilities';
 
-const ELEMENTS = 3
-const SIZE = 80
+const ELEMENTS = 3;
+const SIZE = 80;
 
 function generateColors(name, colors) {
-  const numFromName = getNumber(name)
-  const range = colors && colors.length
+  const numFromName = getNumber(name);
+  const range = colors && colors.length;
 
-  const elementsProperties = Array.from({length: ELEMENTS}, (_,i) => ({
+  const elementsProperties = Array.from({ length: ELEMENTS }, (_, i) => ({
     color: getRandomColor(numFromName + i, colors, range),
     translateX: getUnit(numFromName * (i + 1), SIZE / 10, 1),
     translateY: getUnit(numFromName * (i + 1), SIZE / 10, 2),
-    scale: (1.2 + (getUnit(numFromName * (i + 1), SIZE / 20) / 10)),
-    rotate: getUnit(numFromName * (i + 1), 360, 1)
+    scale: 1.2 + getUnit(numFromName * (i + 1), SIZE / 20) / 10,
+    rotate: getUnit(numFromName * (i + 1), 360, 1),
   }));
 
-  return elementsProperties
+  return elementsProperties;
 }
 
-const AvatarMarble = ( props ) => {
-  const properties = generateColors(props.name, props.colors)
+const AvatarMarble = (props) => {
+  const properties = generateColors(props.name, props.colors);
 
   return (
     <svg
-      viewBox={"0 0 " + SIZE + " " + SIZE}
+      viewBox={'0 0 ' + SIZE + ' ' + SIZE}
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       width={props.size}
       height={props.size}
     >
-      <mask
-        id="mask__marble"
-        maskUnits="userSpaceOnUse"
-        x={0}
-        y={0}
-        width={SIZE}
-        height={SIZE}
-      >
-        <rect width={SIZE} height={SIZE} rx={SIZE*2} fill="white"/>
+      <mask id="mask__marble" maskUnits="userSpaceOnUse" x={0} y={0} width={SIZE} height={SIZE}>
+        <rect width={SIZE} height={SIZE} rx={SIZE * 2} fill="white" />
       </mask>
       <g mask="url(#mask__marble)">
-        <rect width={SIZE} height={SIZE} rx="2" fill={properties[0].color}/>
+        <rect width={SIZE} height={SIZE} rx="2" fill={properties[0].color} />
         <path
           filter="url(#prefix__filter0_f)"
           d="M32.414 59.35L50.376 70.5H72.5v-71H33.728L26.5 13.381l19.057 27.08L32.414 59.35z"
           fill={properties[1].color}
-          transform={"translate(" + properties[1].translateX + " " + properties[1].translateY + ") rotate(" + properties[1].rotate + " " + SIZE / 2 + " " + SIZE / 2  +") scale(" + (properties[2].scale) + ")"}
+          transform={
+            'translate(' +
+            properties[1].translateX +
+            ' ' +
+            properties[1].translateY +
+            ') rotate(' +
+            properties[1].rotate +
+            ' ' +
+            SIZE / 2 +
+            ' ' +
+            SIZE / 2 +
+            ') scale(' +
+            properties[2].scale +
+            ')'
+          }
         />
         <path
           filter="url(#prefix__filter0_f)"
           style={{
-            mixBlendMode: "overlay",
+            mixBlendMode: 'overlay',
           }}
           d="M22.216 24L0 46.75l14.108 38.129L78 86l-3.081-59.276-22.378 4.005 12.972 20.186-23.35 27.395L22.215 24z"
           fill={properties[2].color}
-          transform={"translate(" + properties[2].translateX + " " + properties[2].translateY + ") rotate(" + properties[2].rotate + " " + SIZE / 2 + " " + SIZE / 2  +") scale(" + (properties[2].scale) + ")"}
+          transform={
+            'translate(' +
+            properties[2].translateX +
+            ' ' +
+            properties[2].translateY +
+            ') rotate(' +
+            properties[2].rotate +
+            ' ' +
+            SIZE / 2 +
+            ' ' +
+            SIZE / 2 +
+            ') scale(' +
+            properties[2].scale +
+            ')'
+          }
         />
       </g>
       <defs>
@@ -70,7 +91,7 @@ const AvatarMarble = ( props ) => {
         </filter>
       </defs>
     </svg>
-  )
-}
+  );
+};
 
-export default AvatarMarble
+export default AvatarMarble;

--- a/src/lib/components/avatar-marble.js
+++ b/src/lib/components/avatar-marble.js
@@ -29,7 +29,6 @@ const AvatarMarble = ( props ) => {
       xmlns="http://www.w3.org/2000/svg"
       width={props.size}
       height={props.size}
-      {...props}
     >
       <mask
         id="mask__marble"

--- a/src/lib/components/avatar-marble.js
+++ b/src/lib/components/avatar-marble.js
@@ -38,16 +38,10 @@ const AvatarMarble = ( props ) => {
         width={SIZE}
         height={SIZE}
       >
-        <path
-          d="M80 40C80 17.909 62.091 0 40 0S0 17.909 0 40s17.909 40 40 40 40-17.909 40-40z"
-          fill="#fff"
-        />
+        <rect width={SIZE} height={SIZE} rx={SIZE*2} fill="white"/>
       </mask>
       <g mask="url(#mask__marble)">
-        <path
-          d="M80 40C80 17.909 62.091 0 40 0S0 17.909 0 40s17.909 40 40 40 40-17.909 40-40z"
-          fill={properties[0].color}
-        />
+        <rect width={SIZE} height={SIZE} rx="2" fill={properties[0].color}/>
         <path
           filter="url(#prefix__filter0_f)"
           d="M32.414 59.35L50.376 70.5H72.5v-71H33.728L26.5 13.381l19.057 27.08L32.414 59.35z"

--- a/src/lib/components/avatar-pixel.js
+++ b/src/lib/components/avatar-pixel.js
@@ -35,7 +35,7 @@ const AvatarSunset = (props) => {
         width={SIZE}
         height={SIZE}
       >
-        <rect width={SIZE} height={SIZE} rx={SIZE * 2} fill="white" />
+        <rect width={SIZE} height={SIZE} rx={!props.square && SIZE * 2} fill="white" />
       </mask>
       <g mask="url(#mask0)">
         <rect width={10} height={10} fill={properties[0].color} />

--- a/src/lib/components/avatar-pixel.js
+++ b/src/lib/components/avatar-pixel.js
@@ -35,7 +35,7 @@ const AvatarSunset = ( props ) => {
         width={SIZE}
         height={SIZE}
       >
-        <circle cx={SIZE/2} cy={SIZE/2} r={SIZE/2} fill="white" />
+        <rect width={SIZE} height={SIZE} rx={SIZE*2} fill="white"/>
       </mask>
       <g mask="url(#mask0)">
         <rect width={10} height={10} fill={properties[0].color} />

--- a/src/lib/components/avatar-pixel.js
+++ b/src/lib/components/avatar-pixel.js
@@ -1,26 +1,26 @@
-import * as React from "react"
-import { getNumber, getRandomColor } from '../utilities'
+import * as React from 'react';
+import { getNumber, getRandomColor } from '../utilities';
 
-const ELEMENTS = 64
-const SIZE = 80
+const ELEMENTS = 64;
+const SIZE = 80;
 
 function generateColors(name, colors) {
-  const numFromName = getNumber(name)
-  const range = colors && colors.length
+  const numFromName = getNumber(name);
+  const range = colors && colors.length;
 
-  const elementsProperties = Array.from({length: ELEMENTS}, (_,i) => ({
-    color: getRandomColor(numFromName % (i+13), colors, range),
+  const elementsProperties = Array.from({ length: ELEMENTS }, (_, i) => ({
+    color: getRandomColor(numFromName % (i + 13), colors, range),
   }));
 
-  return elementsProperties
+  return elementsProperties;
 }
 
-const AvatarSunset = ( props ) => {
-  const properties = generateColors(props.name, props.colors)
+const AvatarSunset = (props) => {
+  const properties = generateColors(props.name, props.colors);
 
   return (
     <svg
-      viewBox={"0 0 " + SIZE + " " + SIZE}
+      viewBox={'0 0 ' + SIZE + ' ' + SIZE}
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       width={props.size}
@@ -35,7 +35,7 @@ const AvatarSunset = ( props ) => {
         width={SIZE}
         height={SIZE}
       >
-        <rect width={SIZE} height={SIZE} rx={SIZE*2} fill="white"/>
+        <rect width={SIZE} height={SIZE} rx={SIZE * 2} fill="white" />
       </mask>
       <g mask="url(#mask0)">
         <rect width={10} height={10} fill={properties[0].color} />
@@ -104,7 +104,7 @@ const AvatarSunset = ( props ) => {
         <rect x={70} y={70} width={10} height={10} fill={properties[63].color} />
       </g>
     </svg>
-  )
-}
+  );
+};
 
-export default AvatarSunset
+export default AvatarSunset;

--- a/src/lib/components/avatar-pixel.js
+++ b/src/lib/components/avatar-pixel.js
@@ -25,7 +25,6 @@ const AvatarSunset = ( props ) => {
       xmlns="http://www.w3.org/2000/svg"
       width={props.size}
       height={props.size}
-      {...props}  
     >
       <mask
         id="mask0"

--- a/src/lib/components/avatar-ring.js
+++ b/src/lib/components/avatar-ring.js
@@ -36,7 +36,7 @@ const AvatarRing = (props) => {
       height={props.size}
     >
       <mask id="mask__ring" maskUnits="userSpaceOnUse" x={0} y={0} width={SIZE} height={SIZE}>
-        <rect width={SIZE} height={SIZE} rx={SIZE * 2} fill="white" />
+        <rect width={SIZE} height={SIZE} rx={!props.square && SIZE * 2} fill="white" />
       </mask>
       <g mask="url(#mask__ring)">
         <path d="M0 0h90v45H0z" fill={cellColors[0]} />

--- a/src/lib/components/avatar-ring.js
+++ b/src/lib/components/avatar-ring.js
@@ -32,7 +32,6 @@ const AvatarRing = ( props ) => {
       xmlns="http://www.w3.org/2000/svg"
       width={props.size}
       height={props.size}
-      {...props}
     >
       <path d="M90 45a45.001 45.001 0 00-76.82-31.82A45 45 0 000 45h90z" fill={cellColors[0]} />
       <path d="M90 45a45.001 45.001 0 01-76.82 31.82A45 45 0 010 45h90z" fill={cellColors[1]} />

--- a/src/lib/components/avatar-ring.js
+++ b/src/lib/components/avatar-ring.js
@@ -1,47 +1,42 @@
-import React from 'react'
-import { getNumber, getRandomColor } from '../utilities'
+import React from 'react';
+import { getNumber, getRandomColor } from '../utilities';
 
-const SIZE = 90
-const COLORS = 5
+const SIZE = 90;
+const COLORS = 5;
 
 function generateColors(colors, name) {
-  const numFromName = getNumber(name)
-  const range = colors && colors.length
-  const colorsShuffle = Array.from({length: COLORS}, (_, i) => getRandomColor(numFromName + (i+1), colors, range));
-  const iconColors = []
-  iconColors[0] = colorsShuffle[0]
-  iconColors[1] = colorsShuffle[1]
-  iconColors[2] = colorsShuffle[1]
-  iconColors[3] = colorsShuffle[2]
-  iconColors[4] = colorsShuffle[2]
-  iconColors[5] = colorsShuffle[3]
-  iconColors[6] = colorsShuffle[3]
-  iconColors[7] = colorsShuffle[0]
-  iconColors[8] = colorsShuffle[4]
+  const numFromName = getNumber(name);
+  const range = colors && colors.length;
+  const colorsShuffle = Array.from({ length: COLORS }, (_, i) =>
+    getRandomColor(numFromName + (i + 1), colors, range),
+  );
+  const iconColors = [];
+  iconColors[0] = colorsShuffle[0];
+  iconColors[1] = colorsShuffle[1];
+  iconColors[2] = colorsShuffle[1];
+  iconColors[3] = colorsShuffle[2];
+  iconColors[4] = colorsShuffle[2];
+  iconColors[5] = colorsShuffle[3];
+  iconColors[6] = colorsShuffle[3];
+  iconColors[7] = colorsShuffle[0];
+  iconColors[8] = colorsShuffle[4];
 
-  return iconColors
+  return iconColors;
 }
 
-const AvatarRing = ( props ) => {
-  const cellColors = generateColors(props.colors, props.name)
+const AvatarRing = (props) => {
+  const cellColors = generateColors(props.colors, props.name);
 
   return (
     <svg
-      viewBox={"0 0 " + SIZE + " " + SIZE}
+      viewBox={'0 0 ' + SIZE + ' ' + SIZE}
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       width={props.size}
       height={props.size}
     >
-      <mask
-        id="mask__ring"
-        maskUnits="userSpaceOnUse"
-        x={0}
-        y={0}
-        width={SIZE}
-        height={SIZE}
-      >
-        <rect width={SIZE} height={SIZE} rx={SIZE*2} fill="white"/>
+      <mask id="mask__ring" maskUnits="userSpaceOnUse" x={0} y={0} width={SIZE} height={SIZE}>
+        <rect width={SIZE} height={SIZE} rx={SIZE * 2} fill="white" />
       </mask>
       <g mask="url(#mask__ring)">
         <path d="M0 0h90v45H0z" fill={cellColors[0]} />
@@ -55,7 +50,7 @@ const AvatarRing = ( props ) => {
         <circle cx={45} cy={45} r={23} fill={cellColors[8]} />
       </g>
     </svg>
-  )
-}
+  );
+};
 
-export default AvatarRing
+export default AvatarRing;

--- a/src/lib/components/avatar-ring.js
+++ b/src/lib/components/avatar-ring.js
@@ -33,15 +33,27 @@ const AvatarRing = ( props ) => {
       width={props.size}
       height={props.size}
     >
-      <path d="M90 45a45.001 45.001 0 00-76.82-31.82A45 45 0 000 45h90z" fill={cellColors[0]} />
-      <path d="M90 45a45.001 45.001 0 01-76.82 31.82A45 45 0 010 45h90z" fill={cellColors[1]} />
-      <path d="M83 45a38 38 0 00-76 0h76z" fill={cellColors[2]} />
-      <path d="M83 45a38 38 0 01-76 0h76z" fill={cellColors[3]} />
-      <path d="M77 45a32 32 0 10-64 0h64z" fill={cellColors[4]} />
-      <path d="M77 45a32 32 0 11-64 0h64z" fill={cellColors[5]} />
-      <path d="M71 45a26 26 0 00-52 0h52z" fill={cellColors[6]} />
-      <path d="M71 45a26 26 0 01-52 0h52z" fill={cellColors[7]} />
-      <circle cx={45} cy={45} r={23} fill={cellColors[8]} />
+      <mask
+        id="mask__ring"
+        maskUnits="userSpaceOnUse"
+        x={0}
+        y={0}
+        width={SIZE}
+        height={SIZE}
+      >
+        <rect width={SIZE} height={SIZE} rx={SIZE*2} fill="white"/>
+      </mask>
+      <g mask="url(#mask__ring)">
+        <path d="M0 0h90v45H0z" fill={cellColors[0]} />
+        <path d="M0 45h90v45H0z" fill={cellColors[1]} />
+        <path d="M83 45a38 38 0 00-76 0h76z" fill={cellColors[2]} />
+        <path d="M83 45a38 38 0 01-76 0h76z" fill={cellColors[3]} />
+        <path d="M77 45a32 32 0 10-64 0h64z" fill={cellColors[4]} />
+        <path d="M77 45a32 32 0 11-64 0h64z" fill={cellColors[5]} />
+        <path d="M71 45a26 26 0 00-52 0h52z" fill={cellColors[6]} />
+        <path d="M71 45a26 26 0 01-52 0h52z" fill={cellColors[7]} />
+        <circle cx={45} cy={45} r={23} fill={cellColors[8]} />
+      </g>
     </svg>
   )
 }

--- a/src/lib/components/avatar-sunset.js
+++ b/src/lib/components/avatar-sunset.js
@@ -26,7 +26,6 @@ const AvatarSunset = ( props ) => {
       xmlns="http://www.w3.org/2000/svg"
       width={props.size}
       height={props.size}
-      {...props}
     >
       <mask
         id="mask__sunset"

--- a/src/lib/components/avatar-sunset.js
+++ b/src/lib/components/avatar-sunset.js
@@ -1,63 +1,56 @@
-import * as React from "react"
-import { getNumber, getRandomColor } from '../utilities'
+import * as React from 'react';
+import { getNumber, getRandomColor } from '../utilities';
 
-const ELEMENTS = 4
-const SIZE = 80
+const ELEMENTS = 4;
+const SIZE = 80;
 
 function generateColors(name, colors) {
-  const numFromName = getNumber(name)
-  const range = colors && colors.length
+  const numFromName = getNumber(name);
+  const range = colors && colors.length;
 
-  const elementsProperties = Array.from({length: ELEMENTS}, (_,i) => ({
+  const elementsProperties = Array.from({ length: ELEMENTS }, (_, i) => ({
     color: getRandomColor(numFromName + i, colors, range),
   }));
 
-  return elementsProperties
+  return elementsProperties;
 }
 
-const AvatarSunset = ( props ) => {
-  const properties = generateColors(props.name, props.colors)
+const AvatarSunset = (props) => {
+  const properties = generateColors(props.name, props.colors);
   const name = props.name.replace(/\s/g, '');
 
   return (
     <svg
-      viewBox={"0 0 " + SIZE + " " + SIZE}
+      viewBox={'0 0 ' + SIZE + ' ' + SIZE}
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       width={props.size}
       height={props.size}
     >
-      <mask
-        id="mask__sunset"
-        maskUnits="userSpaceOnUse"
-        x={0}
-        y={0}
-        width={SIZE}
-        height={SIZE}
-      >
-        <rect width={SIZE} height={SIZE} rx={SIZE*2} fill="white"/>
+      <mask id="mask__sunset" maskUnits="userSpaceOnUse" x={0} y={0} width={SIZE} height={SIZE}>
+        <rect width={SIZE} height={SIZE} rx={SIZE * 2} fill="white" />
       </mask>
       <g mask="url(#mask__sunset)">
-        <path fill={"url(#gradient_paint0_linear_"+ name +")"} d="M0 0h80v40H0z" />
-        <path fill={"url(#gradient_paint1_linear_"+ name +")"} d="M0 40h80v40H0z" />
+        <path fill={'url(#gradient_paint0_linear_' + name + ')'} d="M0 0h80v40H0z" />
+        <path fill={'url(#gradient_paint1_linear_' + name + ')'} d="M0 40h80v40H0z" />
       </g>
       <defs>
         <linearGradient
-          id={"gradient_paint0_linear_"+ name}
-          x1={SIZE/2}
+          id={'gradient_paint0_linear_' + name}
+          x1={SIZE / 2}
           y1={0}
-          x2={SIZE/2}
-          y2={SIZE/2}
+          x2={SIZE / 2}
+          y2={SIZE / 2}
           gradientUnits="userSpaceOnUse"
         >
           <stop stopColor={properties[0].color} />
           <stop offset={1} stopColor={properties[1].color} />
         </linearGradient>
         <linearGradient
-          id={"gradient_paint1_linear_"+ name}
-          x1={SIZE/2}
-          y1={SIZE/2}
-          x2={SIZE/2}
+          id={'gradient_paint1_linear_' + name}
+          x1={SIZE / 2}
+          y1={SIZE / 2}
+          x2={SIZE / 2}
           y2={SIZE}
           gradientUnits="userSpaceOnUse"
         >
@@ -66,7 +59,7 @@ const AvatarSunset = ( props ) => {
         </linearGradient>
       </defs>
     </svg>
-  )
-}
+  );
+};
 
-export default AvatarSunset
+export default AvatarSunset;

--- a/src/lib/components/avatar-sunset.js
+++ b/src/lib/components/avatar-sunset.js
@@ -35,7 +35,7 @@ const AvatarSunset = ( props ) => {
         width={SIZE}
         height={SIZE}
       >
-        <circle cx={SIZE/2} cy={SIZE/2} r={SIZE/2} fill="white" />
+        <rect width={SIZE} height={SIZE} rx={SIZE*2} fill="white"/>
       </mask>
       <g mask="url(#mask__sunset)">
         <path fill={"url(#gradient_paint0_linear_"+ name +")"} d="M0 0h80v40H0z" />

--- a/src/lib/components/avatar-sunset.js
+++ b/src/lib/components/avatar-sunset.js
@@ -28,7 +28,7 @@ const AvatarSunset = (props) => {
       height={props.size}
     >
       <mask id="mask__sunset" maskUnits="userSpaceOnUse" x={0} y={0} width={SIZE} height={SIZE}>
-        <rect width={SIZE} height={SIZE} rx={SIZE * 2} fill="white" />
+        <rect width={SIZE} height={SIZE} rx={!props.square && SIZE * 2} fill="white" />
       </mask>
       <g mask="url(#mask__sunset)">
         <path fill={'url(#gradient_paint0_linear_' + name + ')'} d="M0 0h80v40H0z" />

--- a/src/lib/components/avatar.js
+++ b/src/lib/components/avatar.js
@@ -1,45 +1,46 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import AvatarBauhaus from './avatar-bauhaus'
-import AvatarRing from './avatar-ring'
-import AvatarPixel from './avatar-pixel'
-import AvatarBeam from './avatar-beam'
-import AvatarSunset from './avatar-sunset'
-import AvatarMarble from './avatar-marble'
+import React from 'react';
+import PropTypes from 'prop-types';
+import AvatarBauhaus from './avatar-bauhaus';
+import AvatarRing from './avatar-ring';
+import AvatarPixel from './avatar-pixel';
+import AvatarBeam from './avatar-beam';
+import AvatarSunset from './avatar-sunset';
+import AvatarMarble from './avatar-marble';
 
-const variants = ['pixel','bauhaus','ring','beam','sunset','marble']
-const deprecatedVariants = {geometric: 'beam', abstract: 'bauhaus'}
+const variants = ['pixel', 'bauhaus', 'ring', 'beam', 'sunset', 'marble'];
+const deprecatedVariants = { geometric: 'beam', abstract: 'bauhaus' };
 
 const Avatar = ({
   variant = 'marble',
   colors = ['#92A1C6', '#146A7C', '#F0AB3D', '#C271B4', '#C20D90'],
   name = 'Clara Barton',
+  square = false,
   size = 40,
   ...props
 }) => {
-  const avatarProps = {colors, name, size, ...props}
+  const avatarProps = { colors, name, size, square, ...props };
   const checkedVariant = () => {
-    if(Object.keys(deprecatedVariants).includes(variant)) {
-      return deprecatedVariants[variant]
+    if (Object.keys(deprecatedVariants).includes(variant)) {
+      return deprecatedVariants[variant];
     }
-    if(variants.includes(variant)) {
-      return variant
+    if (variants.includes(variant)) {
+      return variant;
     }
-    return 'marble'
-  }
+    return 'marble';
+  };
   const avatars = {
-    pixel: <AvatarPixel {...avatarProps}/>,
-    bauhaus: <AvatarBauhaus {...avatarProps}/>,
-    ring: <AvatarRing {...avatarProps}/>,
-    beam: <AvatarBeam {...avatarProps}/>,
-    sunset: <AvatarSunset {...avatarProps}/>,
-    marble: <AvatarMarble {...avatarProps}/>,
-  }
-  return avatars[checkedVariant()]
-}
+    pixel: <AvatarPixel {...avatarProps} />,
+    bauhaus: <AvatarBauhaus {...avatarProps} />,
+    ring: <AvatarRing {...avatarProps} />,
+    beam: <AvatarBeam {...avatarProps} />,
+    sunset: <AvatarSunset {...avatarProps} />,
+    marble: <AvatarMarble {...avatarProps} />,
+  };
+  return avatars[checkedVariant()];
+};
 
 Avatar.propTypes = {
-  variant: PropTypes.oneOf(variants)
-}
+  variant: PropTypes.oneOf(variants),
+};
 
-export default Avatar
+export default Avatar;


### PR DESCRIPTION
Hey everyone 👋

Exposing `square` prop to modify the mask shape for all variants and allow square-shaped avatars, as some variants were only conceived to have circular shapes. This option will allow custom CSS border-radius within any wrapper.

Thanks for your patience and time 🙇‍♂️

https://user-images.githubusercontent.com/912236/121574770-e5543080-ca26-11eb-94ee-7b5f37e0ee54.mov

Other fixes:
- Remove invalid HTML attributes -> https://github.com/boringdesigners/boring-avatars/issues/17
- Add prettier config file