### PR TITLE
Add copy palette button

### DIFF
--- a/src/demo/playground.js
+++ b/src/demo/playground.js
@@ -226,6 +226,11 @@ const Playground = () => {
           <ColorDot value={dotColor3} onChange={(color) => setDotColor3(color)} />
           <ColorDot value={dotColor4} onChange={(color) => setDotColor4(color)} />
         </ColorsSection>
+        <CopyToClipboard
+          text={`['${dotColor0}', '${dotColor1}', '${dotColor2}', '${dotColor3}', '${dotColor4}']`}
+        >
+          <Button>Copy palette</Button>
+        </CopyToClipboard>
 
         <Button onClick={() => handleRandomColors()}>Random palette</Button>
         <Button onClick={() => setSquare(!isSquare)}>{isSquare ? 'Round' : 'Square'}</Button>


### PR DESCRIPTION
Hi! :)

I'm a big fan of this project, and I use it on my side projects all the time.

It's always a pain to copy individual hex code and paste them. I thought it would be nice to create a 'Copy palette' button next to the 'Random palette' button to make copying the array of palettes easier.

![image](https://user-images.githubusercontent.com/18402191/125266155-61f25d00-e2ba-11eb-8c67-59d2c5f23b25.png)

For example, clicking the copy button would copy the current palette as an array of hex codes.

`['#1b325f', '#9cc4e4', '#e9f2f9', '#3a89c9', '#f26c4f']`

This pull request does not need any extra dependencies.

Warm regards,
ggomaeng