### PR TITLE
Make mask ids unique to avatar instances

### DIFF
--- a/src/lib/components/avatar-pixel.js
+++ b/src/lib/components/avatar-pixel.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { hashCode, getRandomColor } from '../utilities';
+import { useId } from '../useId';
 
 const ELEMENTS = 64;
 const SIZE = 80;
@@ -16,6 +17,7 @@ function generateColors(name, colors) {
 }
 
 const AvatarPixel = (props) => {
+  const maskId = useId();
   const pixelColors = generateColors(props.name, props.colors);
 
   return (
@@ -29,7 +31,7 @@ const AvatarPixel = (props) => {
     >
       <title>{props.name}</title>
       <mask
-        id="mask__pixel"
+        id={maskId}
         mask-type="alpha"
         maskUnits="userSpaceOnUse"
         x={0}
@@ -39,7 +41,7 @@ const AvatarPixel = (props) => {
       >
         <rect width={SIZE} height={SIZE} rx={props.square ?  undefined : SIZE * 2} fill="#FFFFFF" />
       </mask>
-      <g mask="url(#mask__pixel)">
+      <g mask={`url(#${maskId})`}>
         <rect width={10} height={10} fill={pixelColors[0]} />
         <rect x={20} width={10} height={10} fill={pixelColors[1]} />
         <rect x={40} width={10} height={10} fill={pixelColors[2]} />

--- a/src/lib/useId.js
+++ b/src/lib/useId.js
@@ -1,0 +1,3 @@
+import * as React from 'react';
+
+export const useId = () => React.useMemo(() => `r:${Math.random().toString().substring(2, 7)}`, []);


### PR DESCRIPTION
### Why

If an app has multiple instances of the same type of avatar on the page and one of those avatars is hidden, the visible avatar may reference the hidden avatar's mask element as its own mask. This results in the visible avatar no longer being circular because the mask no longer has effect. Tested in chrome.

### How

- Create a poor man's polyfill of React 18's `useId`
- Replace the avatar's mask id with the result of `useId`, making it unique to the instance so there's no cross-referencing

PR is just a POC for `avatar-pixel`