### PR TITLE
Adds support for a new `Image` variant and an accompanying `src` prop.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,20 +27,22 @@ import Avatar from "boring-avatars";
   size={40}
   name="Maria Mitchell"
   variant="marble"
+  src=""
   colors={["#92A1C6", "#146A7C", "#F0AB3D", "#C271B4", "#C20D90"]}
 />;
 ```
 
 ### Props
 
-| Prop    | Type                                                         |
-| ------- | ------------------------------------------------------------ |
-| size    | number or string, `40px` (default)                           |
-| square  | boolean: `false` (default)                                   |
-| title   | boolean: `false` (default)                                   |
-| name    | string                                                       |
-| variant | oneOf: `marble` (default), `beam`, `pixel`,`sunset`, `ring`, `bauhaus` |
-| colors  | array of colors                                              |
+| Prop    | Type                                                                            |
+|---------|---------------------------------------------------------------------------------|
+| size    | number or string, `40px` (default)                                              |
+| square  | boolean: `false` (default)                                                      |
+| title   | boolean: `false` (default)                                                      |
+| name    | string                                                                          |
+| variant | oneOf: `marble` (default), `beam`, `pixel`,`sunset`, `ring`, `bauhaus`, `image` |
+| colors  | array of colors                                                                 |
+| src     | string (utilized with the `image` variant)                                      |
 
 
 ## Service

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,8 +3,9 @@ declare module "boring-avatars" {
     size?: number | string;
     name?: string;
     square?: boolean;
-    variant?: "marble" | "beam" | "pixel" | "sunset" | "ring" | "bauhaus";
+    variant?: "marble" | "beam" | "pixel" | "sunset" | "ring" | "bauhaus" | "image";
     colors?: string[];
+    src?: string;
   }
 
   interface AvatarComponent {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17319,6 +17319,20 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/uglify-js": {
       "version": "3.4.10",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.10.tgz",
@@ -33143,6 +33157,13 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "peer": true
     },
     "uglify-js": {
       "version": "3.4.10",

--- a/src/demo/playground.js
+++ b/src/demo/playground.js
@@ -70,7 +70,7 @@ const Input = styled.input`
   }
 `;
 
-const AvatarWrapper = ({ name, playgroundColors, size, square, variant }) => {
+const AvatarWrapper = ({ name, playgroundColors, size, square, variant, src }) => {
   const [avatarName, setAvatarName] = useState(name);
   const handleFocus = (event) => event.target.select();
   const ref = useRef();
@@ -96,6 +96,7 @@ const AvatarWrapper = ({ name, playgroundColors, size, square, variant }) => {
           size={size}
           variant={variants[variant]}
           square={square}
+          src={src}
         />
       </AvatarSection>
       <Input
@@ -154,6 +155,12 @@ const variants = {
   sunset: 'sunset',
   pixel: 'pixel',
   marble: 'marble',
+  image: 'image',
+};
+
+const imageExamples = {
+  screenshot: 'https://github.com/boringdesigners/boring-avatars/blob/master/public/boring-avatars-preview.png?raw=true',
+  service: 'https://source.boringavatars.com/marble/120/Maria%20Mitchell?colors=264653,2a9d8f,e9c46a,f4a261,e76f51',
 };
 
 const Playground = () => {
@@ -182,6 +189,7 @@ const Playground = () => {
 
   const [avatarSize, setAvatarSize] = useState(avatarSizes.medium);
   const [variant, setVariant] = useState(variants.beam);
+  const [imageSrc, setImageSrc] = useState(imageExamples.screenshot);
   const [isSquare, setSquare] = useState(false);
 
   return (
@@ -243,6 +251,7 @@ const Playground = () => {
             name={exampleName}
             playgroundColors={filteredColors}
             variant={variant}
+            src={imageSrc}
           />
         ))}
       </AvatarsGrid>

--- a/src/lib/components/avatar-image.js
+++ b/src/lib/components/avatar-image.js
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+const AvatarImage = (props) => {
+  const styles = {
+    borderRadius: props.square ? 'inherit' : '50%',
+  };
+  return (
+    <img
+      style={styles}
+      width={props.size}
+      height={props.size}
+      src={props.src}
+      alt={props.name}
+    >
+    </img>
+  );
+};
+
+export default AvatarImage;

--- a/src/lib/components/avatar.js
+++ b/src/lib/components/avatar.js
@@ -6,20 +6,22 @@ import AvatarPixel from './avatar-pixel';
 import AvatarBeam from './avatar-beam';
 import AvatarSunset from './avatar-sunset';
 import AvatarMarble from './avatar-marble';
+import AvatarImage from './avatar-image';
 
-const variants = ['pixel', 'bauhaus', 'ring', 'beam', 'sunset', 'marble'];
+const variants = ['pixel', 'bauhaus', 'ring', 'beam', 'sunset', 'marble', 'image'];
 const deprecatedVariants = { geometric: 'beam', abstract: 'bauhaus' };
 
 const Avatar = ({
   variant = 'marble',
   colors = ['#92A1C6', '#146A7C', '#F0AB3D', '#C271B4', '#C20D90'],
   name = 'Clara Barton',
+  src = '',
   square = false,
   title = false,
   size = 40,
   ...props
 }) => {
-  const avatarProps = { colors, name, title, size, square, ...props };
+  const avatarProps = { colors, name, title, size, square, src, ...props };
   const checkedVariant = () => {
     if (Object.keys(deprecatedVariants).includes(variant)) {
       return deprecatedVariants[variant];
@@ -36,6 +38,7 @@ const Avatar = ({
     beam: <AvatarBeam {...avatarProps} />,
     sunset: <AvatarSunset {...avatarProps} />,
     marble: <AvatarMarble {...avatarProps} />,
+    image: <AvatarImage {...avatarProps} />,
   };
   return avatars[checkedVariant()];
 };


### PR DESCRIPTION
Hi there, I'm a big fan of the boring-avatars library, but need to be able to display either an uploaded user photo or a placeholder avatar, depending on whether the user has uploaded a photo or not.

To address this, I've added a new `image` variant that can be used with a new `src` prop to display an image. The Image variant supports both the `round` and `square` modes, making it easy to "upgrade" the avatar without changing the component.

I hope that others will find this new variant useful as well! 

<img width="729" alt="Screen Shot 2023-02-16 at 10 37 09 PM" src="https://user-images.githubusercontent.com/831521/219544736-cbf73c48-17c1-44e6-829b-5d71e1e99f95.png">
<img width="723" alt="Screen Shot 2023-02-16 at 10 37 17 PM" src="https://user-images.githubusercontent.com/831521/219544739-120c7af4-b49e-400d-85a9-241dc2f15224.png">


